### PR TITLE
Fix stray markup in highlights section

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,11 +128,6 @@
                     </div>
                 </div>
             </div>
-        </section>           <a href="#" class="btn-small">MÁS INFO</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
         </section>
 
         <section id="contact" class="section">


### PR DESCRIPTION
## Summary
- remove leftover tags after the last project card
- ensure `<section id="highlights">` closes before the contact section

## Testing
- `python3 - <<'EOF'
import sys, html
from html.parser import HTMLParser
class Parser(HTMLParser):
    def error(self, message):
        print('error', message)

p = Parser()
with open('index.html') as f:
    p.feed(f.read())
print('parsed ok')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6851da61564083319287a6861e887667