### PR TITLE
Add Jest setup and dark mode test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Santiago
+
+This project contains a simple website with a dark mode toggle.
+
+## Running tests
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Run the test suite:
+   ```bash
+   npm test
+   ```
+
+The tests use [Jest](https://jestjs.io/) and validate the dark mode toggle behaviour.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "santiago",
+  "version": "1.0.0",
+  "description": "",
+  "main": "script.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.0.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}

--- a/script.test.js
+++ b/script.test.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+
+// Helper to stub matchMedia
+beforeEach(() => {
+  document.body.innerHTML = `
+    <button id="darkModeToggle" aria-label="Alternar modo oscuro/claro"></button>
+    <nav><a href="#section1">Link</a></nav>
+    <section id="section1"></section>
+  `;
+  localStorage.clear();
+  window.matchMedia = jest.fn().mockReturnValue({
+    matches: false,
+    addEventListener: () => {},
+    removeEventListener: () => {}
+  });
+
+  jest.resetModules();
+  require('./script');
+  document.dispatchEvent(new Event('DOMContentLoaded'));
+});
+
+describe('dark mode toggle', () => {
+  test('toggles class and label', () => {
+    const button = document.getElementById('darkModeToggle');
+    const body = document.body;
+
+    // initial state
+    expect(body.classList.contains('dark-mode')).toBe(false);
+    expect(button.textContent).toBe('🌙');
+    expect(button.getAttribute('aria-label')).toBe('Alternar a modo oscuro');
+
+    // first click activates dark mode
+    button.click();
+    expect(body.classList.contains('dark-mode')).toBe(true);
+    expect(button.textContent).toBe('☀️');
+    expect(button.getAttribute('aria-label')).toBe('Alternar a modo claro');
+
+    // second click restores light mode
+    button.click();
+    expect(body.classList.contains('dark-mode')).toBe(false);
+    expect(button.textContent).toBe('🌙');
+    expect(button.getAttribute('aria-label')).toBe('Alternar a modo oscuro');
+  });
+});


### PR DESCRIPTION
## Summary
- set up a basic `package.json` with Jest
- add a unit test for the dark mode toggle
- document how to run the tests

## Testing
- `npm install --save-dev jest` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851dde0234c8331af38f72d872aad75